### PR TITLE
Use HEROKU_APP_NAME env var in the webhook URL's hostname

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -248,7 +248,7 @@ def start_bot():
         updater.start_webhook(listen='0.0.0.0',
                               port=int(port),
                               url_path=api_key,
-                              webhook_url="https://telegram-bot-help-ua-ch.herokuapp.com/" + api_key)
+                              webhook_url=f"https://{os.environ.get('HEROKU_APP_NAME', 'telegram-bot-help-ua-ch')}.herokuapp.com/{api_key}")
     else:
         updater.start_polling()
 


### PR DESCRIPTION
This allows the bot to run in other Heroku apps. The default value still remains "telegram-bot-help-ua-ch".

This env var along with other metadata flags can be added to config vars automatically with the following command:
```
$ heroku labs:enable runtime-dyno-metadata
```