### PR TITLE
Fix logging of leaf conversation nodes in stats

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -159,7 +159,7 @@ def choice(update: Update, context: CallbackContext) -> int:
 
     current_node_name = user_data["current_node"]
     user_id = update.message.from_user.id
-    bot_stats.collect(user_id, current_node_name)
+    bot_stats.collect(user_id, next_node_name)
 
     current_node = CONVERSATION_DATA["node_by_name"][next_node_name]
     current_keyboard_options = [
@@ -340,7 +340,9 @@ def start_bot():
     updater.idle()
 
 
-def visit_node(node: conversation_proto.ConversationNode, consumer, visited: Set = set()):
+def visit_node(node: conversation_proto.ConversationNode, consumer, visited: Set=None):
+    if visited is None:
+        visited = set()
     visited.add(node.name)
     consumer(node)
     if len(node.link) > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,5 @@ cryptography==36.0.2
 protobuf==3.19.4
 pytest==7.0.1
 python-telegram-bot==13.11
+pytz==2022.1
 redis==4.1.4

--- a/stats.py
+++ b/stats.py
@@ -1,12 +1,14 @@
 from typing import Dict
 from collections import Counter
+from pytz import timezone
 import hashlib
 import datetime
 
 HOUR = datetime.timedelta(hours=1).total_seconds()
 THREEHOURS = datetime.timedelta(hours=3).total_seconds()
 DAY = datetime.timedelta(days=1).total_seconds()
-
+BOT_TIMEZONE = timezone("Europe/Zurich")
+STARTTIME_UTC = datetime.datetime.now(BOT_TIMEZONE)
 
 class Stats:
     timestamp_by_user: Dict[str, float]
@@ -38,5 +40,7 @@ class Stats:
             daily += 1 if user_ts > now - DAY else 0
 
         node_stats = "\n".join([f"\t- {n}: {c}" for n, c in self.interactions.most_common(10)])
-        user_stats = f"\t- 1h: {hourly}\n\t- 3h: {threehourly}\n\t- 1d: {daily}"
-        return f"Total users:\n{user_stats}\nTop 10 interactions:\n{node_stats}"
+        user_stats = f"\t- 1h: {hourly}\n\t- 3h: {threehourly}\n\t- 24h: {daily}"
+        now_tz = datetime.datetime.now(BOT_TIMEZONE)
+        uptime = str(now_tz - STARTTIME_UTC).split('.')[0]
+        return f"Start time: {now_tz.replace(microsecond=0)}\nUptime: {uptime}\nTotal users:\n{user_stats}\nTop 10 interactions:\n{node_stats}"


### PR DESCRIPTION
Drive-by:
- Improve stats output (1d -> 24h), add bot start time and uptime
- Fix an error-prone default function param value