### PR TITLE
stats: persist statistics in redis if configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ an env variable `FEEDBACK_CHANNEL_ID`. Here's how you test the bot:
 - [ ] GUI editor of a conversation tree
 - [X] Data pulls of conversation tree from GitHub on command
 - [ ] Inline buttons. A scripter should be allowed to choose what kind of buttons to have attached. They should work same as keyboard buttons.
-- [ ] Persistent stats collection to redis.
+- [x] Persistent stats collection to redis.
 - [x] Simple Stats collection. We should collect basic stats (number of users, etc). Stats could be made accessible via a command.
 - [x] Persistent sessions. Persist bot state across restarts (in an encrypted form).
 - [x] Option to collect feedback.

--- a/bot.py
+++ b/bot.py
@@ -30,7 +30,6 @@ import ssl
 import telegram.error
 import traceback
 import urllib.request
-
 import stats
 
 logging.basicConfig(
@@ -38,7 +37,7 @@ logging.basicConfig(
     level=logging.INFO,
 )
 logger = logging.getLogger(__name__)
-bot_stats = stats.Stats()
+bot_stats: stats.Stats = None
 
 CONVERSATION_TREE_URL = "https://raw.githubusercontent.com/skd/telegram-bot-help-ua-ch/main/conversation_tree.textproto"
 DEFAULT_WEBHOOK_URL = "https://telegram-bot-help-ua-ch.herokuapp.com"
@@ -79,20 +78,19 @@ ADMIN_USERS = [
 
 CONVERSATION_DATA = {}
 PHOTO_CACHE = {}
-BOT_PERSISTENCE_DATABASE = 0
+FEEDBACK_CHANNEL_ID = None
+BOT_PERSISTENCE_DATABASE, BOT_METRICS_DATABASE = range(2)
 
 
-def redis_instance():
-    redis_url = os.getenv("REDIS_TLS_URL")
-    if redis_url is None:
-        redis_url = "redis://localhost:6379"
+def redis_instance(redis_db: int):
+    redis_url = os.getenv("REDIS_TLS_URL", "redis://localhost:6379")
 
     url = urlparse(redis_url)
     use_ssl = url.scheme == 'rediss'
     logger.info(
         f"Enabling Redis-based bot persistence.\nRedis on: {url.hostname}:{url.port}\nUse SSL: {use_ssl}")
     return redis.Redis(
-        db=BOT_PERSISTENCE_DATABASE,
+        db=redis_db,
         host=url.hostname, port=url.port,
         username=url.username, password=url.password,
         ssl=use_ssl, ssl_cert_reqs=None,
@@ -107,7 +105,7 @@ def redis_persistence():
             "*** EMPTY BOT_STATE_ENCRYPTION_KEY *** YOU SHOULD NEVER SEE THIS IN PROD ***")
     else:
         encryption_key_bytes = encryption_key.encode()
-    rd = redis_instance()
+    rd = redis_instance(BOT_PERSISTENCE_DATABASE)
     return RedisPersistence(rd, encryption_key_bytes)
 
 
@@ -284,7 +282,7 @@ def choice(update: Update, context: CallbackContext) -> int:
 
     current_node_name = user_data["current_node"]
     user_id = update.message.from_user.id
-    bot_stats.collect(user_id, next_node_name)
+    bot_stats.collect_interaction(user_id, next_node_name)
 
     current_node = CONVERSATION_DATA["node_by_name"].get(next_node_name)
     if not current_node:
@@ -432,6 +430,13 @@ def conversation_handler(persistent: bool):
     )
 
 
+def init_stats():
+    global bot_stats
+    storage = stats.RedisStorage(redis_instance(BOT_METRICS_DATABASE)) \
+        if os.getenv("PERSIST_METRICS", "") == "true" else stats.MemStorage()
+    bot_stats = stats.Stats(storage)
+
+
 def reset_user_state(context: CallbackContext):
     context.user_data["current_node"] = START_NODE
     context.user_data["nav_stack"] = [START_NODE]
@@ -446,7 +451,7 @@ def start_bot():
 
     if os.getenv("USE_WEBHOOK", "") == "true":
         port = int(os.environ.get("PORT", 5000))
-        logger.log(logging.INFO, "Starting webhook at port %s", port)
+        logger.log(logging.INFO, f"Starting webhook at port {port}")
         updater.start_webhook(
             listen="0.0.0.0",
             port=int(port),
@@ -499,6 +504,7 @@ def main():
     with open("conversation_tree.textproto", "r") as f:
         f_buffer = f.read()
     reset_bot_data(f_buffer)
+    init_stats()
     start_bot()
 
 

--- a/stats.py
+++ b/stats.py
@@ -1,67 +1,160 @@
-from typing import Dict
-from collections import Counter
+from typing import Dict, List
+from collections import Counter, defaultdict
 from pytz import timezone
+
+import math
 import hashlib
 import datetime
+import redis
 
-HOUR = datetime.timedelta(hours=1).total_seconds()
-THREEHOURS = datetime.timedelta(hours=3).total_seconds()
-DAY = datetime.timedelta(days=1).total_seconds()
+TIME_BUCKETS = {
+    "1h": datetime.timedelta(hours=1).total_seconds(),
+    "3h": datetime.timedelta(hours=3).total_seconds(),
+    "24h": datetime.timedelta(days=1).total_seconds(),
+}
+TOP_K_INTERACTIONS = 20
+HOUR_SEC = int(datetime.timedelta(hours=1).total_seconds())
+
 BOT_TIMEZONE = timezone("Europe/Zurich")
 STARTTIME_TZ = datetime.datetime.now(BOT_TIMEZONE)
 DATETIME_FORMAT = "%Y-%m-%d %H:%M:%S"
-TOP_K_INTERACTIONS = 20
+
+METRICS_RETENTION = datetime.timedelta(days=3)
+REDIS_USER_NS = "user"
+REDIS_NODE_NS = "node"
+
+
+class Storage:
+
+    def store_interaction(self, user_id: str, node: str, ts: int):
+        pass
+
+    def get_users_data(self) -> List[int]:
+        pass
+
+    def get_interactions_data(self) -> Counter[str]:
+        pass
+
 
 class Stats:
-    timestamp_by_user: Dict[str, float]
-    interactions: Counter
+
+    storage: Storage
     last_reload_time_tz: datetime.datetime
     last_reloader_username: str
 
-    def __init__(self):
-        self.timestamp_by_user = dict()
-        self.interactions = Counter()
+    def __init__(self, storage: Storage):
+        self.storage = storage
         self.last_reload_time_tz = None
         self.last_reloader_username = None
 
-    def hash_user(self, user_id: int) -> str:
-        return hashlib.sha256(user_id.to_bytes(10, byteorder='big', signed=True)).hexdigest()
-
-    def collect(self, user_id: int, node: str):
-        # collect user stats
-        user_hash = self.hash_user(user_id)
-        self.timestamp_by_user[user_hash] = datetime.datetime.now().timestamp()
-        # collect node stats
-        self.interactions[node] += 1
+    def collect_interaction(self, user_id: int, node: str):
+        ts = int(datetime.datetime.now(BOT_TIMEZONE).timestamp())
+        return self.storage.store_interaction(hash_user(user_id), node, ts)
 
     def conversation_reloaded(self, username):
         self.last_reload_time_tz = datetime.datetime.now(BOT_TIMEZONE)
         self.last_reloader_username = username
 
     def compute(self) -> str:
-        hourly = 0
-        threehourly = 0
-        daily = 0
-        now = datetime.datetime.now().timestamp()
-        for u in self.timestamp_by_user:
-            user_ts = self.timestamp_by_user[u]
-            hourly += 1 if user_ts > now - HOUR else 0
-            threehourly += 1 if user_ts > now - THREEHOURS else 0
-            daily += 1 if user_ts > now - DAY else 0
-
-        node_stats = "\n".join([f"\t- {n}: {c}" for n, c in self.interactions.most_common(TOP_K_INTERACTIONS)])
-        user_stats = f"\t- 1h: {hourly}\n\t- 3h: {threehourly}\n\t- 24h: {daily}"
         now_tz = datetime.datetime.now(BOT_TIMEZONE)
         uptime = now_tz - STARTTIME_TZ
         uptime = datetime.timedelta(seconds=int(uptime.total_seconds()))
+
+        now_ts = int(now_tz.timestamp())
+        interacts_data = self.storage.get_interactions_data().most_common(TOP_K_INTERACTIONS)
+        users_data = defaultdict(int)
+        for user_ts in self.storage.get_users_data():
+            for k, bucket_ts in TIME_BUCKETS.items():
+                if user_ts > now_ts - bucket_ts:
+                    users_data[k] += 1
+
+        users_stats = "\n".join([f"\t- {i}: {c}" for i, c in users_data.items()])
+        interacts_stats = "\n".join([f"\t- {n}: {c}" for n, c in interacts_data])
+
         output = [
             f"Start time: {STARTTIME_TZ.strftime(DATETIME_FORMAT)}",
             f"Uptime: {uptime}"
         ]
         if self.last_reload_time_tz:
             output.append(f"Last conversation reload: {self.last_reload_time_tz.strftime(DATETIME_FORMAT)} ({self.last_reloader_username})")
+
         output.extend([
-            f"Total users:\n{user_stats}",
-            f"Top {TOP_K_INTERACTIONS} interactions:\n{node_stats}"
+            f"Total users:\n{users_stats}",
+            f"Top {TOP_K_INTERACTIONS} interactions:\n{interacts_stats}"
         ])
         return "\n".join(output)
+
+
+class RedisStorage(Storage):
+
+    rd: redis.Redis
+
+    def __init__(self, rd: redis.Redis):
+        self.rd = rd
+
+    def store_interaction(self, user_id: str, node: str, ts: int):
+        pipeline = self.rd.pipeline()
+        pipeline.setex(
+            f"{REDIS_USER_NS}:{user_id}",
+            METRICS_RETENTION,
+            ts,
+        )
+        bucket = self.hbucket(ts, 1)
+        pipeline.hincrby(f"{REDIS_NODE_NS}:{bucket}", node, 1)
+        pipeline.expire(
+            f"{REDIS_NODE_NS}:{bucket}",
+            METRICS_RETENTION,
+        )
+        pipeline.execute()
+
+    def get_users_data(self) -> List[int]:
+        users_data = []
+        for user in self.rd.scan_iter(f"{REDIS_USER_NS}:*"):
+            users_data.append(int(self.rd.get(user)))
+
+        return users_data
+
+    def get_interactions_data(self) -> Counter[str]:
+        interacts_data = Counter()
+        for bucket in self.hourly_buckets(METRICS_RETENTION.total_seconds()):
+            node_stats = self.rd.hgetall(f"{REDIS_NODE_NS}:{bucket}").items()
+            for node, node_interacts in node_stats:
+                interacts_data[node.decode("utf-8")] += int(node_interacts)
+
+        return interacts_data
+
+    def hourly_buckets(self, stats_period: int) -> List[int]:
+        now_ts = int(datetime.datetime.now(BOT_TIMEZONE).timestamp())
+        num_buckets = math.ceil(stats_period / HOUR_SEC)
+        buckets = []
+        for i in range(1, num_buckets + 1):
+            buckets.append(self.hbucket(now_ts, i))
+
+        return buckets
+
+    def hbucket(self, now_ts: int, bucket: int) -> int:
+        return now_ts - (now_ts % HOUR_SEC) - HOUR_SEC * (bucket - 1)
+
+
+class MemStorage(Storage):
+
+    timestamp_by_user: Dict[str, int]
+    interactions: Counter()
+
+    def __init__(self):
+        self.timestamp_by_user = {}
+        self.interactions = Counter()
+
+    def store_interaction(self, user_id: str, node: str, ts: int):
+        self.timestamp_by_user[user_id] = ts
+        self.interactions[node] += 1
+
+    def get_users_data(self) -> List[int]:
+        return self.timestamp_by_user.values()
+
+    def get_interactions_data(self) -> Counter[str]:
+        return self.interactions
+
+
+def hash_user(user_id: int) -> str:
+    return hashlib.sha256(user_id.to_bytes(10, byteorder='big', signed=True)).hexdigest()


### PR DESCRIPTION
To enable redis storage for metrics, necessary to define the ENV var
`PERSIST_METRICS=true`.

It uses only the default functionality of redis, as in order to use timeseries
or bloom filter modules, first necessary to enable a module on redis server,
which afaik  not supported on Heroku (only enterprise version).